### PR TITLE
fix(ci): configure Changesets action permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,9 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
   release:
+    permissions:
+      contents: write # to create release (changesets/action)
+      pull-requests: write # to create pull request (changesets/action)
     name: Release
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This PR configures the release GitHub Action with the proper [`GITHUB_TOKEN` permissions](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs#assigning-permissions-to-a-specific-job) for `changesets/action`.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [X] Clearly illustrate what problems this PR would solve.
- [ ] Link related issues or PRs that this PR would close, if any, using `closes #number`.
- [X] Lint and format your code by running `pnpm lint` and `pnpm format`.
- [ ] If your PR makes a change that should be noted in the changelogs for one or more apps or packages, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, and so on.
