### PR TITLE
fix(ci): remove conflicting `pnpm version` script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Create Release Pull Request
         uses: changesets/action@v1
         with:
-          version: pnpm version
+          version: pnpm release
           commit: "chore: version packages"
           title: "chore: version packages"
         env:

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint": "turbo run lint",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "changeset": "changeset",
-    "version": "changeset version"
+    "release": "changeset version"
   },
   "devDependencies": {
     "@changesets/cli": "^2.26.0",


### PR DESCRIPTION
It seems that `pnpm version` is a built-in pnpm CLI command. This PR renames the script for running `changeset version` to `pnpm release` instead to avoid conflicting names and updates the release action to run that instead.

---

### Please don't delete this checklist! Before submitting the PR, please make sure you do the following:

- [X] Clearly illustrate what problems this PR would solve.
- [ ] Link related issues or PRs that this PR would close, if any, using `closes #number`.
- [X] Lint and format your code by running `pnpm lint` and `pnpm format`.
- [ ] If your PR makes a change that should be noted in the changelogs for one or more apps or packages, generate a changeset by running `pnpm changeset` and following the prompts. Changesets that add features should be `minor` and those that fix bugs should be `patch`. Please prefix changeset messages with `feat:`, `fix:`, and so on.
